### PR TITLE
Boulder history

### DIFF
--- a/HuiputinPaivakirja/src/components/ClickableRoute.js
+++ b/HuiputinPaivakirja/src/components/ClickableRoute.js
@@ -1,7 +1,7 @@
-import { View, Text } from 'react-native'
+import { View, Text as Text, Pressable } from 'react-native'
 import React from 'react'
-import Svg, { Polygon } from 'react-native-svg'
 import styles from '../styles/Styles'
+import RoutePolygon from './RoutePolygon';
 
 export default function ClickableRoute({data, onPress}) {
   const formatDate = (isoString) => {
@@ -13,13 +13,18 @@ export default function ClickableRoute({data, onPress}) {
     const minutes = String(date.getMinutes()).padStart(2, '0');
     return `${year}-${month}-${day} ${hours}:${minutes}`;
   };
-  
+
   return (
-    <View style={styles.inputContainer}>
-        <Text style={styles.basicText}>Route: {data.route.routeName}</Text>
-        <Text style={styles.basicText}>Grade: {data.route.votedGrade}</Text>
-        <Text style={styles.basicText}>Sent At: {formatDate(data.send.sentAt)}</Text>
-        <Text style={styles.basicText}>Tries: {data.send.tries}</Text>
-    </View>
+    <Pressable onPress={onPress}>   
+    {({ pressed }) => (
+        <View style={[styles.ClickableRouteContainer, { backgroundColor: pressed ? 'lightgray' : 'white' }]}>
+            <RoutePolygon gradeColor={data.route.routeGradeColor} holdColor={data.route.routeHoldColor} votedGrade={data.route.votedGrade}/>
+            <View style={styles.verticalContainerRouteInfo}>
+                <Text style={styles.smallText}>{data.route.routeName}</Text>
+                <Text style={styles.smallText}>{formatDate(data.send.sentAt)}</Text>
+            </View>
+        </View>
+    )}
+    </Pressable>
   )
 }

--- a/HuiputinPaivakirja/src/components/ClickableRoute.js
+++ b/HuiputinPaivakirja/src/components/ClickableRoute.js
@@ -1,0 +1,25 @@
+import { View, Text } from 'react-native'
+import React from 'react'
+import Svg, { Polygon } from 'react-native-svg'
+import styles from '../styles/Styles'
+
+export default function ClickableRoute({data, onPress}) {
+  const formatDate = (isoString) => {
+    const date = new Date(isoString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day} ${hours}:${minutes}`;
+  };
+  
+  return (
+    <View style={styles.inputContainer}>
+        <Text style={styles.basicText}>Route: {data.route.routeName}</Text>
+        <Text style={styles.basicText}>Grade: {data.route.votedGrade}</Text>
+        <Text style={styles.basicText}>Sent At: {formatDate(data.send.sentAt)}</Text>
+        <Text style={styles.basicText}>Tries: {data.send.tries}</Text>
+    </View>
+  )
+}

--- a/HuiputinPaivakirja/src/components/RoutePictureModal.js
+++ b/HuiputinPaivakirja/src/components/RoutePictureModal.js
@@ -15,9 +15,8 @@ export default function ModalView({
       onRequestClose={onClose}
     >
       <View style={modalStyles.centeredView}>
-        <View style={modalStyles.modalView}>
-            <Image source={{uri: routeImageUrl}} style={{width: '100%', height: 550}}/>
-            <View style={modalStyles.modalButtonContainer}>
+            <Image source={{uri: routeImageUrl}} style={{width: '80%', height: 550, margin: 10}}/>
+            <View style={modalStyles.picureModalButtonView}>
             <TouchableOpacity
                 style={modalStyles.modalButton}
                 onPress={onClose}
@@ -25,7 +24,6 @@ export default function ModalView({
                 <Text style={modalStyles.modalButtonText}>Close</Text>
             </TouchableOpacity>
             </View>
-        </View>
       </View>
     </Modal>
   );

--- a/HuiputinPaivakirja/src/components/RoutePictureModal.js
+++ b/HuiputinPaivakirja/src/components/RoutePictureModal.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, TextInput, Image } from 'react-native';
+import modalStyles from '../styles/ModalStyles';
+
+export default function ModalView({
+  visible,
+  onClose,
+  routeImageUrl,
+}) {
+  return (
+    <Modal
+      animationType="slide"
+      transparent={true}
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <View style={modalStyles.centeredView}>
+        <View style={modalStyles.modalView}>
+            <Image source={{uri: routeImageUrl}} style={{width: '100%', height: 550}}/>
+            <View style={modalStyles.modalButtonContainer}>
+            <TouchableOpacity
+                style={modalStyles.modalButton}
+                onPress={onClose}
+            >
+                <Text style={modalStyles.modalButtonText}>Close</Text>
+            </TouchableOpacity>
+            </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/HuiputinPaivakirja/src/components/RoutePolygon.js
+++ b/HuiputinPaivakirja/src/components/RoutePolygon.js
@@ -15,7 +15,7 @@ export default function RoutePolygon({gradeColor, holdColor, votedGrade}) {
         <Text
             x="30"
             y="30"
-            fill="white"
+            fill={holdColor === 'white' || holdColor === 'yellow' || holdColor === 'pink' ? 'black' : 'white'}
             fontSize="15"
             textAnchor="middle"
             fontWeight="bold"

--- a/HuiputinPaivakirja/src/components/RoutePolygon.js
+++ b/HuiputinPaivakirja/src/components/RoutePolygon.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import Svg, { Polygon, Text } from 'react-native-svg'
+
+export default function RoutePolygon({gradeColor, holdColor, votedGrade}) {
+  return (
+    <Svg height="60" width="60">
+        <Polygon
+            points="30,0 60,30 30,60 0,30"
+            fill={gradeColor}
+        />
+        <Polygon
+            points="30,10 50,30 30,50 10,30"
+            fill={holdColor}
+        />
+        <Text
+            x="30"
+            y="30"
+            fill="white"
+            fontSize="15"
+            textAnchor="middle"
+            fontWeight="bold"
+            alignmentBaseline="middle"
+        >{votedGrade}
+        </Text>
+    </Svg>
+  )
+}

--- a/HuiputinPaivakirja/src/firebase/FirebaseMethods.js
+++ b/HuiputinPaivakirja/src/firebase/FirebaseMethods.js
@@ -273,4 +273,27 @@ const getRouteCreatorId = async (routeId) => {
     }
 };
 
-export { addRouteAndMarker, AddUserInfo, fetchUserData, listenToMarkers, fetchRouteData, voteForDelete, setRouteInvisible, markRouteAsSent, getRouteCreatorId }
+const retrieveBoulderHistory = async () => {
+    try {
+        const userDocRef = doc(users, auth.currentUser.uid);
+        const userDoc = await getDoc(userDocRef);
+        if (userDoc.exists()) {
+            const sends = userDoc.data().sends;
+            const sendsAndRoutes = await Promise.all(sends.map(async (send) => {
+                const routeDocRef = doc(db, 'routes', send.route);
+                const routeDoc = await getDoc(routeDocRef);
+                return { send, route: routeDoc.data() };
+            }));
+
+            return sendsAndRoutes;
+
+        } else {
+            console.log('No user data found!');
+            return null;
+        }
+    } catch (error) {
+        console.error('Error fetching user data:', error);
+        return null;
+    }
+}
+export { addRouteAndMarker, AddUserInfo, fetchUserData, listenToMarkers, fetchRouteData, voteForDelete, setRouteInvisible, markRouteAsSent, getRouteCreatorId, retrieveBoulderHistory }

--- a/HuiputinPaivakirja/src/navigation/MainStackNavigator.js
+++ b/HuiputinPaivakirja/src/navigation/MainStackNavigator.js
@@ -5,7 +5,7 @@ import ProfileScreen from '../screens/ProfileScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import MainViewController from '../screens/MainViewController';
 import BoulderScreen from '../screens/boulderScreen';
-
+import BoulderHistoryScreen from '../screens/BoulderHistoryScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -23,6 +23,7 @@ function MainStackNavigator() {
       <Stack.Screen name="Profile" component={ProfileScreen} />
       <Stack.Screen name="Settings" component={SettingsScreen} />
       <Stack.Screen name="BoulderScreen" component={BoulderScreen} />
+      <Stack.Screen name="BoulderHistoryScreen" component={BoulderHistoryScreen} />
     </Stack.Navigator>
   );
 }

--- a/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
+++ b/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
@@ -1,15 +1,20 @@
-import { View, Text, FlatList } from 'react-native'
+import { View, Text, FlatList, Pressable } from 'react-native'
 import React, { useState, useEffect } from 'react'
 import styles from '../styles/Styles'
 import { useTheme } from 'react-native-paper'
 import LoadingIcon from '../components/LoadingIcon'
 import { retrieveBoulderHistory } from '../firebase/FirebaseMethods'
 import ClickableRoute from '../components/ClickableRoute'
+import DrawerButton from '../components/DrawerButton'
+import { useNavigation } from '@react-navigation/native'
 
 export default function BoulderHistoryScreen() {
   const { colors, fonts } = useTheme()
   const [history, setHistory] = useState([])
+  const [allHistory, setAllHistory] = useState([])
   const [loading, setLoading] = useState(true)
+  const [seeAllHistory, setSeeAllHistory] = useState(false)
+  const navigation = useNavigation()
 
   useEffect(() => {
     const fetchHistory = async () => {
@@ -18,6 +23,7 @@ export default function BoulderHistoryScreen() {
             // Sort the sends list by sentAt field in descending order
             const sortedSends = data.sort((a, b) => new Date(b.send.sentAt) - new Date(a.send.sentAt));
             // Take the last five sends
+            setAllHistory(sortedSends);
             const lastFiveSends = sortedSends.slice(0, 5);
             setHistory(lastFiveSends);
             setLoading(false);
@@ -44,17 +50,25 @@ export default function BoulderHistoryScreen() {
   }
 
   return (
-    <View style={styles.screenBaseContainer}>
+    <View style={[styles.screenBaseContainer,{backgroundColor: colors.background}]}>
+      <DrawerButton navigation={navigation} />
       <View style={styles.headerContainer}>
         <Text style={{fontFamily: fonts.special.fontFamily, fontSize: 28 }}>Boulder History</Text>
       </View>
+      <Text style={[styles.basicText, styles.bold, styles.marginLeft16]}>Your last 5 sends:</Text>
       <FlatList
-        data={history}
+        data={seeAllHistory? allHistory : history}
+        style={styles.inputContainer}
         keyExtractor={(item, index) => index.toString()}
         renderItem={({ item, index }) => (
-          <ClickableRoute data={item} onPress={() => {}} />
+          <ClickableRoute key={index} data={item} onPress={() => {console.log("Press")}} />
         )}
       />
+      <Pressable onPress={() => setSeeAllHistory(!seeAllHistory)}>
+        <Text style={[styles.basicText, styles.bold, styles.marginLeft16]}>
+            {!seeAllHistory ? "See all your sends" : "See only last 5 sends"}
+        </Text>
+      </Pressable>
     </View>
   )
 }

--- a/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
+++ b/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
@@ -4,6 +4,7 @@ import styles from '../styles/Styles'
 import { useTheme } from 'react-native-paper'
 import LoadingIcon from '../components/LoadingIcon'
 import { retrieveBoulderHistory } from '../firebase/FirebaseMethods'
+import ClickableRoute from '../components/ClickableRoute'
 
 export default function BoulderHistoryScreen() {
   const { colors, fonts } = useTheme()
@@ -51,12 +52,7 @@ export default function BoulderHistoryScreen() {
         data={history}
         keyExtractor={(item, index) => index.toString()}
         renderItem={({ item, index }) => (
-          <View style={styles.inputContainer}>
-            <Text style={styles.basicText}>Route: {history[index].route.routeName}</Text>
-            <Text style={styles.basicText}>Grade: {history[index].route.votedGrade}</Text>
-            <Text style={styles.basicText}>Sent At: {formatDate(history[index].send.sentAt)}</Text>
-            <Text style={styles.basicText}>Tries: {history[index].send.tries}</Text>
-          </View>
+          <ClickableRoute data={item} onPress={() => {}} />
         )}
       />
     </View>

--- a/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
+++ b/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
@@ -55,10 +55,10 @@ export default function BoulderHistoryScreen() {
       <View style={styles.headerContainer}>
         <Text style={{fontFamily: fonts.special.fontFamily, fontSize: 28 }}>Boulder History</Text>
       </View>
-      <Text style={[styles.basicText, styles.bold, styles.marginLeft16]}>Your last 5 sends:</Text>
+      <Text style={[styles.basicText, styles.bold, styles.marginLeft16]}>Your last sends:</Text>
       <FlatList
         data={seeAllHistory? allHistory : history}
-        style={styles.inputContainer}
+        style={[styles.inputContainer]}
         keyExtractor={(item, index) => index.toString()}
         renderItem={({ item, index }) => (
           <ClickableRoute key={index} data={item} onPress={() => {console.log("Press")}} />

--- a/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
+++ b/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
@@ -1,0 +1,16 @@
+import { View, Text } from 'react-native'
+import React from 'react'
+import styles from '../styles/Styles'
+import { useTheme } from 'react-native-paper'
+
+export default function BoulderHistoryScreen() {
+  const { colors, fonts } = useTheme()
+
+  return (
+    <View style={styles.screenBaseContainer}>
+      <View style={styles.headerContainer}>
+        <Text style={{fontFamily: fonts.special.fontFamily, fontSize: 28 }}>Boulder History</Text>
+      </View>
+    </View>
+  )
+}

--- a/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
+++ b/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
@@ -7,6 +7,7 @@ import { retrieveBoulderHistory } from '../firebase/FirebaseMethods'
 import ClickableRoute from '../components/ClickableRoute'
 import DrawerButton from '../components/DrawerButton'
 import { useNavigation } from '@react-navigation/native'
+import RoutePictureModal from '../components/RoutePictureModal'
 
 export default function BoulderHistoryScreen() {
   const { colors, fonts } = useTheme()
@@ -15,6 +16,8 @@ export default function BoulderHistoryScreen() {
   const [loading, setLoading] = useState(true)
   const [seeAllHistory, setSeeAllHistory] = useState(false)
   const navigation = useNavigation()
+  const [modalVisible, setModalVisible] = useState(false)
+  const [imageUri, setImageUri] = useState(null)
 
   useEffect(() => {
     const fetchHistory = async () => {
@@ -33,14 +36,10 @@ export default function BoulderHistoryScreen() {
     fetchHistory();
   }, []);
 
-  const formatDate = (isoString) => {
-    const date = new Date(isoString);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
-    return `${year}-${month}-${day} ${hours}:${minutes}`;
+  const handleRoutePress = (imageUrl) => {
+    console.log('Image URL: ', imageUrl);
+    setImageUri(imageUrl);
+    setModalVisible(true);
   };
 
   if (loading) {
@@ -51,6 +50,7 @@ export default function BoulderHistoryScreen() {
 
   return (
     <View style={[styles.screenBaseContainer,{backgroundColor: colors.background}]}>
+      <RoutePictureModal visible={modalVisible} onClose={()=>{setModalVisible(false)}} routeImageUrl={imageUri} />
       <DrawerButton navigation={navigation} />
       <View style={styles.headerContainer}>
         <Text style={{fontFamily: fonts.special.fontFamily, fontSize: 28 }}>Boulder History</Text>
@@ -65,11 +65,11 @@ export default function BoulderHistoryScreen() {
       </View>
       <ScrollView style={styles.inputContainer}>
         {!seeAllHistory && history.length > 0 && history.map((item, index) => (
-            <ClickableRoute key={index} data={item} onPress={() => {console.log("Press")}} />
-            ))}
+            <ClickableRoute key={index} data={item} onPress={() => {handleRoutePress(item.route.routeImageUrl)}} />
+        ))}
         {seeAllHistory && allHistory.length > 0 && allHistory.map((item, index) => (
-            <ClickableRoute key={index} data={item} onPress={() => {console.log("Press")}} />
-            ))}
+            <ClickableRoute key={index} data={item} onPress={() => {handleRoutePress(item.route.routeImageUrl)}} />
+        ))}
       </ScrollView>
     </View>
   )

--- a/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
+++ b/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
@@ -1,4 +1,4 @@
-import { View, Text, FlatList, Pressable } from 'react-native'
+import { View, Text, FlatList, Pressable, ScrollView } from 'react-native'
 import React, { useState, useEffect } from 'react'
 import styles from '../styles/Styles'
 import { useTheme } from 'react-native-paper'
@@ -55,20 +55,22 @@ export default function BoulderHistoryScreen() {
       <View style={styles.headerContainer}>
         <Text style={{fontFamily: fonts.special.fontFamily, fontSize: 28 }}>Boulder History</Text>
       </View>
-      <Text style={[styles.basicText, styles.bold, styles.marginLeft16]}>Your last sends:</Text>
-      <FlatList
-        data={seeAllHistory? allHistory : history}
-        style={[styles.inputContainer]}
-        keyExtractor={(item, index) => index.toString()}
-        renderItem={({ item, index }) => (
-          <ClickableRoute key={index} data={item} onPress={() => {console.log("Press")}} />
-        )}
-      />
-      <Pressable onPress={() => setSeeAllHistory(!seeAllHistory)}>
-        <Text style={[styles.basicText, styles.bold, styles.marginLeft16]}>
-            {!seeAllHistory ? "See all your sends" : "See only last 5 sends"}
-        </Text>
-      </Pressable>
+      <View style={styles.horizontalSpaceBetween}>
+        <Text style={[styles.basicText, styles.bold]}>Your last sends:</Text>
+        <Pressable onPress={() => setSeeAllHistory(!seeAllHistory)}>
+            <Text style={[styles.basicText, styles.bold, styles.marginLeft16, {color: 'blue'}]}>
+                {!seeAllHistory ? "See all" : "See less"}
+            </Text>
+        </Pressable>
+      </View>
+      <ScrollView style={styles.inputContainer}>
+        {!seeAllHistory && history.length > 0 && history.map((item, index) => (
+            <ClickableRoute key={index} data={item} onPress={() => {console.log("Press")}} />
+            ))}
+        {seeAllHistory && allHistory.length > 0 && allHistory.map((item, index) => (
+            <ClickableRoute key={index} data={item} onPress={() => {console.log("Press")}} />
+            ))}
+      </ScrollView>
     </View>
   )
 }

--- a/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
+++ b/HuiputinPaivakirja/src/screens/BoulderHistoryScreen.js
@@ -1,16 +1,64 @@
-import { View, Text } from 'react-native'
-import React from 'react'
+import { View, Text, FlatList } from 'react-native'
+import React, { useState, useEffect } from 'react'
 import styles from '../styles/Styles'
 import { useTheme } from 'react-native-paper'
+import LoadingIcon from '../components/LoadingIcon'
+import { retrieveBoulderHistory } from '../firebase/FirebaseMethods'
 
 export default function BoulderHistoryScreen() {
   const { colors, fonts } = useTheme()
+  const [history, setHistory] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+        const data = await retrieveBoulderHistory();
+        if (data) {
+            // Sort the sends list by sentAt field in descending order
+            const sortedSends = data.sort((a, b) => new Date(b.send.sentAt) - new Date(a.send.sentAt));
+            // Take the last five sends
+            const lastFiveSends = sortedSends.slice(0, 5);
+            setHistory(lastFiveSends);
+            setLoading(false);
+        }
+    };
+
+    fetchHistory();
+  }, []);
+
+  const formatDate = (isoString) => {
+    const date = new Date(isoString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day} ${hours}:${minutes}`;
+  };
+
+  if (loading) {
+    return (
+        <LoadingIcon/>
+    )
+  }
 
   return (
     <View style={styles.screenBaseContainer}>
       <View style={styles.headerContainer}>
         <Text style={{fontFamily: fonts.special.fontFamily, fontSize: 28 }}>Boulder History</Text>
       </View>
+      <FlatList
+        data={history}
+        keyExtractor={(item, index) => index.toString()}
+        renderItem={({ item, index }) => (
+          <View style={styles.inputContainer}>
+            <Text style={styles.basicText}>Route: {history[index].route.routeName}</Text>
+            <Text style={styles.basicText}>Grade: {history[index].route.votedGrade}</Text>
+            <Text style={styles.basicText}>Sent At: {formatDate(history[index].send.sentAt)}</Text>
+            <Text style={styles.basicText}>Tries: {history[index].send.tries}</Text>
+          </View>
+        )}
+      />
     </View>
   )
 }

--- a/HuiputinPaivakirja/src/screens/CameraScreen.js
+++ b/HuiputinPaivakirja/src/screens/CameraScreen.js
@@ -56,16 +56,10 @@ export default function CameraScreen({setRouteImage, handleHideCamera}) {
   };
 
   // Save the picture in the library
-  const savePicture = async (capturedImageUri) => {
+  const savePicture = (capturedImageUri) => {
     if (capturedImageUri) {
-      try {
-      //  await MediaLibrary.saveToLibraryAsync(capturedImageUri) //tallentaa puhelimen muistiin
-      } catch (error) {
-        console.log('Error saving picture: ', error)
-      } finally {
         setImage(null);
         handleHideCamera(capturedImageUri);
-      }
     }
   };
 

--- a/HuiputinPaivakirja/src/screens/ProfileScreen.js
+++ b/HuiputinPaivakirja/src/screens/ProfileScreen.js
@@ -56,6 +56,10 @@ export default function ProfileScreen({ navigation }) {
         Alert.alert("Error saving user data. Please try again.");
     }
   }
+  
+  const handleBoulderHistory = () => {
+    navigation.navigate('BoulderHistoryScreen');
+  }
 
   return (
     <View style={[styles.screenBaseContainer, { backgroundColor: colors.background }]}>
@@ -92,6 +96,17 @@ export default function ProfileScreen({ navigation }) {
           style={styles.buttonLonger}
         >
           Delete my account
+        </Button>
+        <Button
+          mode="contained"
+          onPress={handleBoulderHistory}
+          icon="history"
+          buttonColor={colors.accent}
+          contentStyle={styles.buttonContent}
+          labelStyle={styles.buttonLabel}
+          style={styles.buttonLonger}
+        >
+          Boulder History
         </Button>
       </View>}
       </>}

--- a/HuiputinPaivakirja/src/styles/ModalStyles.js
+++ b/HuiputinPaivakirja/src/styles/ModalStyles.js
@@ -60,6 +60,15 @@ export const modalStyles = StyleSheet.create({
     borderColor: '#ccc',
     borderRadius: 5,
   },
+  picureModalButtonView: {
+    width: '80%',
+    height: 40
+  },
+  modalPicture: {
+    width: '80%',
+    height: 550, 
+    margin: 10
+  },
 });
 
 export default modalStyles;

--- a/HuiputinPaivakirja/src/styles/Styles.js
+++ b/HuiputinPaivakirja/src/styles/Styles.js
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+import ClickableRoute from '../components/ClickableRoute';
 
 export const styles = StyleSheet.create({
     screenBaseContainer: {
@@ -84,6 +85,12 @@ export const styles = StyleSheet.create({
         fontSize: 18,
         marginBottom: 10,
     },
+    marginLeft16: {
+        marginLeft: 16,
+    },
+    bold: {
+        fontWeight: 'bold',
+    },
     notification: {
         position: 'absolute',
         top: 70,
@@ -125,6 +132,36 @@ export const styles = StyleSheet.create({
         marginTop: 32, 
         marginBottom: 16 
     },
+    ClickableRouteContainer: {
+        width: '100%',
+        height: 65,
+        marginBottom: 10,
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderColor: 'gray', // Gray border color
+        borderWidth: 1, // Border width
+        borderRadius: 10, // Border radius
+        shadowColor: '#000', // Shadow color
+        shadowOffset: { width: 0, height: 2 }, // Shadow offset
+        shadowOpacity: 0.25, // Shadow opacity
+        shadowRadius: 3.84, // Shadow radius
+        elevation: 5, // Elevation for Android shadow
+        backgroundColor: 'white', // Background color
+        
+    },
+    verticalContainerRouteInfo: {
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'left',
+        marginLeft: 20,
+        marginTop: 4,
+        marginBottom: 4,
+    },
+    smallText: {
+        fontSize: 14,
+        fontWeight: 'bold',
+        margin: 5
+    }
 });
 
 export default styles;

--- a/HuiputinPaivakirja/src/styles/Styles.js
+++ b/HuiputinPaivakirja/src/styles/Styles.js
@@ -161,7 +161,13 @@ export const styles = StyleSheet.create({
         fontSize: 14,
         fontWeight: 'bold',
         margin: 5
-    }
+    },
+    horizontalSpaceBetween: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingHorizontal: 16,
+    },  
 });
 
 export default styles;

--- a/HuiputinPaivakirja/src/styles/Styles.js
+++ b/HuiputinPaivakirja/src/styles/Styles.js
@@ -1,5 +1,4 @@
 import { StyleSheet } from 'react-native';
-import ClickableRoute from '../components/ClickableRoute';
 
 export const styles = StyleSheet.create({
     screenBaseContainer: {


### PR DESCRIPTION
BoulderHistoryScreen listätty MainStackNavigatoriin. Pääsy boulder historiaan on profiilisivulla. Viimeiset viisi sendiä näkyy, ja lisää voi katsoa napista. Klikkaamalla saa reitin kuvan auki. Tässä nyt tehty sellainen kaksivärinen salmiakki jossa keskellä lukee äänestetty grade. Reitin nimi ja kiipeämispäivämäärä lukee myös listassa. Ominaisuudet testattu.